### PR TITLE
Add fuel cost estimator and CLI interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+from src.routing.fuel_model import estimate_fuel_cost
+
+def main():
+    # Hardcoded input for now
+    distance = 100  # miles
+    fuel_consumption_rate = 0.04  # gallons per mile
+    fuel_price = 3.50  # dollars per gallon
+
+    cost = estimate_fuel_cost(distance, fuel_consumption_rate, fuel_price)
+    print(f"Estimated fuel cost for {distance} miles: ${cost:.2f}")
+
+if __name__ == "__main__":
+    main()

--- a/src/routing/fuel_model.py
+++ b/src/routing/fuel_model.py
@@ -1,0 +1,25 @@
+"""
+Fuel cost estimation module for RouteCraft.
+
+This module provides a simple fuel cost estimation based on 
+distance, fuel consumption rate, and current fuel prices.
+"""
+
+def estimate_fuel_cost(
+    distance: float = 100.0, 
+    fuel_consumption_rate: float = 0.04, 
+    fuel_price: float = 3.50
+) -> float:
+    """
+    Calculate estimated fuel cost for a route.
+    
+    Args:
+        distance (float): Total route distance in miles
+        fuel_consumption_rate (float): Fuel consumption in gallons per mile
+        fuel_price (float): Price of fuel per gallon
+    
+    Returns:
+        float: Estimated total fuel cost
+    """
+    fuel_cost = distance * fuel_consumption_rate * fuel_price
+    return round(fuel_cost, 2)


### PR DESCRIPTION
This PR introduces the first working feature of RouteCraft:

- Implements `estimate_fuel_cost` in `src/routing/fuel_model.py` with a simple cost model
- Adds a CLI in `main.py` that prints the estimated fuel cost for a test route
- Uses hardcoded inputs for now; future branches will make the inputs dynamic

All changes are clean, isolated, and ready to merge into `main`.
